### PR TITLE
Read DB config from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Vendraly
 
 Este repositorio contiene un prototipo de plataforma de microinversiones colaborativas que conecta inversores con emprendedores locales.
+
+## Variables de entorno
+
+El archivo `public/php/config.php` obtiene la configuración de la base de datos de las siguientes variables de entorno:
+
+* `DB_HOST` – Host de la base de datos (por defecto `localhost`).
+* `DB_NAME` – Nombre de la base de datos (por defecto `cambblym_vendraly`).
+* `DB_USER` – Usuario de la base de datos. Requerido si no se usa el valor por defecto.
+* `DB_PASS` – Contraseña del usuario. Requerido si no se usa el valor por defecto.
+
+Si `DB_USER` o `DB_PASS` no están definidos y no se establecen valores por defecto, la aplicación detendrá la ejecución mostrando un mensaje de error descriptivo.

--- a/public/php/config.php
+++ b/public/php/config.php
@@ -1,9 +1,13 @@
 <?php
 // config.php
-$host = 'localhost';
-$dbname = 'cambblym_vendraly';
-$user = 'cambblym_vendraly';
-$pass = '2j)I]V4G^1dV';
+$host = getenv('DB_HOST') ?: 'localhost';
+$dbname = getenv('DB_NAME') ?: 'cambblym_vendraly';
+$user = getenv('DB_USER') ?: 'cambblym_vendraly';
+$pass = getenv('DB_PASS') ?: '2j)I]V4G^1dV';
+
+if (!$user || !$pass) {
+    die('Database credentials not provided. Set DB_USER and DB_PASS environment variables.');
+}
 
 try {
     $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $user, $pass);


### PR DESCRIPTION
## Summary
- read database settings from environment variables in `config.php`
- describe optional DB environment variables in the README

## Testing
- `php -l public/php/config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e15f5ed88327b9f66e5821e30840