### PR TITLE
Unify PHP session key

### DIFF
--- a/public/php/publicar_proyecto.php
+++ b/public/php/publicar_proyecto.php
@@ -1,14 +1,14 @@
 <?php
 session_start();
 
-if (!isset($_SESSION['id'])) {
+if (!isset($_SESSION['usuario_id'])) {
   echo json_encode(['status' => 'error', 'msg' => 'No has iniciado sesión.']);
   exit;
 }
 
 require 'config.php';
 
-$usuario_id = $_SESSION['id'];
+$usuario_id = $_SESSION['usuario_id'];
 $nombre_usuario = $_SESSION['nombre'] ?? 'Usuario';
 
 $tipo = $_POST['tipo'] ?? '';


### PR DESCRIPTION
## Summary
- standardize on `$_SESSION['usuario_id']`
- update `publicar_proyecto.php` to use the consistent session key

## Testing
- `php -l public/php/check_session.php public/php/config.php public/php/login.php public/php/logout.php public/php/publicar_proyecto.php public/php/register.php`

------
https://chatgpt.com/codex/tasks/task_e_6847e3090948832792f1168003db92e1