### PR TITLE
Improve escaping for dynamic names

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -168,11 +168,16 @@ function renderProjects() {
     // Dueño
     const owner = document.createElement('div');
     owner.className = 'owner';
-    owner.innerHTML = `
-      <span>👤</span>
-      <span>Por:</span>
-      <span class="owner-name">${p.owner}</span>
-    `;
+    const ownerIcon = document.createElement('span');
+    ownerIcon.textContent = '👤';
+    const ownerLabel = document.createElement('span');
+    ownerLabel.textContent = 'Por:';
+    const ownerName = document.createElement('span');
+    ownerName.className = 'owner-name';
+    ownerName.textContent = p.owner;
+    owner.appendChild(ownerIcon);
+    owner.appendChild(ownerLabel);
+    owner.appendChild(ownerName);
 
     // Botones
     const buttons = document.createElement('div');

--- a/public/js/oportunidades.js
+++ b/public/js/oportunidades.js
@@ -162,11 +162,16 @@ function renderProjects() {
 
     const owner = document.createElement('div');
     owner.className = 'owner';
-    owner.innerHTML = `
-      <span>👤</span>
-      <span>Por:</span>
-      <span class="owner-name">${p.owner}</span>
-    `;
+    const ownerIcon = document.createElement('span');
+    ownerIcon.textContent = '👤';
+    const ownerLabel = document.createElement('span');
+    ownerLabel.textContent = 'Por:';
+    const ownerName = document.createElement('span');
+    ownerName.className = 'owner-name';
+    ownerName.textContent = p.owner;
+    owner.appendChild(ownerIcon);
+    owner.appendChild(ownerLabel);
+    owner.appendChild(ownerName);
 
     const buttons = document.createElement('div');
     buttons.className = 'buttons';

--- a/public/php/check_session.php
+++ b/public/php/check_session.php
@@ -1,7 +1,8 @@
 <?php
 session_start();
 if (isset($_SESSION["usuario_id"])) {
-    echo json_encode(["logged_in" => true, "nombre" => $_SESSION["nombre"]]);
+    $nombre = htmlspecialchars($_SESSION["nombre"], ENT_QUOTES, 'UTF-8');
+    echo json_encode(["logged_in" => true, "nombre" => $nombre]);
 } else {
     echo json_encode(["logged_in" => false]);
 }

--- a/public/php/login.php
+++ b/public/php/login.php
@@ -18,7 +18,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     if ($user && password_verify($password, $user["password_hash"])) {
         $_SESSION["usuario_id"] = $user["id"];
         $_SESSION["nombre"] = $user["nombre"];
-        echo json_encode(["status" => "ok", "msg" => "Bienvenido " . $user["nombre"]]);
+        $nombre = htmlspecialchars($user["nombre"], ENT_QUOTES, 'UTF-8');
+        echo json_encode(["status" => "ok", "msg" => "Bienvenido " . $nombre]);
     } else {
         echo json_encode(["status" => "error", "msg" => "Credenciales inválidas"]);
     }


### PR DESCRIPTION
## Summary
- escape user names returned from the server
- render owner names via `textContent`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6b4c38483279f82ef4207d97da0