### PR TITLE
Add CSRF token to lectura updates

### DIFF
--- a/js/mensajes.js
+++ b/js/mensajes.js
@@ -160,7 +160,7 @@ async function abrirConversacion(id, nombre) {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        // No es necesario X-CSRF-Token si lo quitaste
+        "X-CSRF-Token": csrfToken
       },
       body: new URLSearchParams({
         conversacion_id: id,
@@ -212,6 +212,21 @@ async function actualizarMensajes() {
 
   const session = await fetchUserSession();
   renderizarMensajes(data, session.id);
+
+  if (data.mensajes && data.mensajes.length) {
+    const ultimo = data.mensajes[data.mensajes.length - 1];
+    fetch("../php/actualizar_ultima_lectura.php", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-CSRF-Token": csrfToken
+      },
+      body: new URLSearchParams({
+        conversacion_id: conversacionAbiertaId,
+        mensaje_id: ultimo.id
+      })
+    });
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- ensure updates to `actualizar_ultima_lectura.php` include CSRF header
- refresh last read message when updating messages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f04a6c6308327889f7222e8e5521d