### PR TITLE
Remove hardcoded DB credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_NAME=vendraly
+DB_USER=your_db_user
+DB_PASS=your_db_password
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/config.js
+++ b/config.js
@@ -1,6 +1,10 @@
+if (!process.env.DB_HOST || !process.env.DB_USER || !process.env.DB_PASS || !process.env.DB_NAME) {
+  throw new Error('Missing required database environment variables');
+}
+
 module.exports = {
-  host: process.env.DB_HOST || 'localhost',
-  user: process.env.DB_USER || 'root',
-  password: process.env.DB_PASS || '01312003',
-  database: process.env.DB_NAME || 'vendraly'
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME
 };

--- a/config.php
+++ b/config.php
@@ -1,12 +1,13 @@
 <?php
 // config.php
-$host = getenv('DB_HOST') ?: 'localhost';
-$dbname = getenv('DB_NAME') ?: 'cambblym_vendraly';
-$user = getenv('DB_USER') ?: 'cambblym_vendraly';
-$pass = getenv('DB_PASS') ?: '2j)I]V4G^1dV';
 
-if (!$user || !$pass) {
-    die('Database credentials not provided. Set DB_USER and DB_PASS environment variables.');
+$host = getenv('DB_HOST');
+$dbname = getenv('DB_NAME');
+$user = getenv('DB_USER');
+$pass = getenv('DB_PASS');
+
+if (!$host || !$dbname || !$user || !$pass) {
+    die('Database credentials not provided. Set DB_HOST, DB_NAME, DB_USER and DB_PASS environment variables.');
 }
 
 try {


### PR DESCRIPTION
## Summary
- switch PHP and Node config to only read DB credentials from env vars
- add `.env.example` with variable placeholders
- ignore local `.env`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `php -l config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad534f3c83279be5d74278b9ebdf