### PR TITLE
Add error handling for fetch operations

### DIFF
--- a/public_html/js/csrf.js
+++ b/public_html/js/csrf.js
@@ -2,19 +2,24 @@ let csrfToken = '';
 
 async function loadCsrfToken() {
   const prefix = location.pathname.includes('/dashboard/') ? '../' : '';
-  const res = await fetch(`${prefix}php/csrf_token.php`);
-  const data = await res.json();
-  csrfToken = data.token;
-  document.querySelectorAll('form').forEach(f => {
-    let hidden = f.querySelector('input[name="csrf_token"]');
-    if (!hidden) {
-      hidden = document.createElement('input');
-      hidden.type = 'hidden';
-      hidden.name = 'csrf_token';
-      f.appendChild(hidden);
-    }
-    hidden.value = csrfToken;
-  });
+  try {
+    const res = await fetch(`${prefix}php/csrf_token.php`);
+    const data = await res.json();
+    csrfToken = data.token;
+    document.querySelectorAll('form').forEach(f => {
+      let hidden = f.querySelector('input[name="csrf_token"]');
+      if (!hidden) {
+        hidden = document.createElement('input');
+        hidden.type = 'hidden';
+        hidden.name = 'csrf_token';
+        f.appendChild(hidden);
+      }
+      hidden.value = csrfToken;
+    });
+  } catch (err) {
+    console.error('Error al obtener el token CSRF', err);
+    alert('No se pudo conectar con el servidor. Intente nuevamente más tarde.');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', loadCsrfToken);

--- a/public_html/js/oportunidades.js
+++ b/public_html/js/oportunidades.js
@@ -2,19 +2,20 @@ async function renderProjects() {
   const grid = document.getElementById('project-grid');
   if (!grid) return;
 
-  const res = await fetch('../php/ver_proyectos_activos.php');
-  const data = await res.json();
+  try {
+    const res = await fetch('../php/ver_proyectos_activos.php');
+    const data = await res.json();
 
-  if (data.status !== 'ok') {
-    grid.innerHTML = '<p>No se pudieron cargar los proyectos.</p>';
-    return;
-  }
+    if (data.status !== 'ok') {
+      grid.innerHTML = '<p>No se pudieron cargar los proyectos.</p>';
+      return;
+    }
 
-  const projects = data.proyectos;
+    const projects = data.proyectos;
 
-  projects.forEach(p => {
-    const card = document.createElement('div');
-    card.className = 'card';
+    projects.forEach(p => {
+      const card = document.createElement('div');
+      card.className = 'card';
 
     const header = document.createElement('div');
     header.className = 'header';
@@ -170,12 +171,20 @@ progressLabel.innerHTML = `
 
     grid.appendChild(card);
   });
+  } catch (err) {
+    console.error('Error al cargar proyectos', err);
+    grid.innerHTML = '<p>No se pudo conectar con el servidor.</p>';
+  }
 }
 
 
 function logout() {
   fetch('../php/logout.php')
-    .then(() => window.location.href = "../index.html");
+    .then(() => window.location.href = "../index.html")
+    .catch(err => {
+      console.error('Error al cerrar sesión', err);
+      alert('No se pudo conectar con el servidor. Intente nuevamente más tarde.');
+    });
 }
 
 function toggleMenu() {


### PR DESCRIPTION
## Summary
- handle fetch failures when retrieving CSRF token
- show an error if opportunities fetch fails
- handle logout fetch failures

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad54e90883278847a81c579d586a